### PR TITLE
Add 'sh -l' in Vagranfile 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,6 @@ boot2docker-vagrant.iso:
 	wget -O boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v${VERSION}/boot2docker.iso
 
 clean:                                                                                                                                                                                                                               
-        rm -rf *.iso *.box
+	rm -rf *.iso *.box
 
 .PHONY: clean prepare build

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,19 @@
-VERSION=1.8.1
+VERSION=1.8.2
 
+all: validate build
+
+validate: template.json
+	packer validate template.json
+	
 build: boot2docker-vagrant.iso
 	time (packer build -parallel=false template.json)
-
+	
 prepare: clean boot2docker-vagrant.iso
 
 boot2docker-vagrant.iso:
 	wget -O boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v${VERSION}/boot2docker.iso
 
-clean:
-	rm -rf *.iso *.box
+clean:                                                                                                                                                                                                                               
+        rm -rf *.iso *.box
 
 .PHONY: clean prepare build

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ prepare: clean boot2docker-vagrant.iso
 boot2docker-vagrant.iso:
 	wget -O boot2docker.iso https://github.com/boot2docker/boot2docker/releases/download/v${VERSION}/boot2docker.iso
 
-clean:                                                                                                                                                                                                                               
+clean:
 	rm -rf *.iso *.box
 
 .PHONY: clean prepare build

--- a/template.json
+++ b/template.json
@@ -1,7 +1,7 @@
 {
     "variables": {
         "B2D_ISO_FILE": "boot2docker.iso",
-        "B2D_ISO_CHECKSUM": "7e231d3c33e08f08b604fdc9a557b64b"
+        "B2D_ISO_CHECKSUM": "29839aeef97758e142eae4c2fd10890b"
     },
     "builders": [{
         "type": "virtualbox-iso",

--- a/template.json
+++ b/template.json
@@ -5,6 +5,7 @@
     },
     "builders": [{
         "type": "virtualbox-iso",
+        "headless": "true",
         "iso_url": "{{user `B2D_ISO_FILE`}}",
         "iso_checksum_type": "md5",
         "iso_checksum": "{{user `B2D_ISO_CHECKSUM`}}",
@@ -16,6 +17,7 @@
         "shutdown_command": "sudo poweroff"
     }, {
         "type": "vmware-iso",
+        "headless": "true",
         "iso_url": "{{user `B2D_ISO_FILE`}}",
         "iso_checksum_type": "md5",
         "iso_checksum": "{{user `B2D_ISO_CHECKSUM`}}",

--- a/vagrantfile.tpl
+++ b/vagrantfile.tpl
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.ssh.shell = "sh"
+  config.ssh.shell = "sh -l"
   config.ssh.username = "docker"
 
   # Used on Vagrant >= 1.7.x to disable the ssh key regeneration


### PR DESCRIPTION
This PR is to add 'sh -l' in the template Vagranfile

This is required to have all the PATH properly set for vmware.

VMTools are installed in /usr/local/sbin.

Updated the box to 1.8.2 (tested)
